### PR TITLE
Fjernet Nav-User-Id custom header i kall til joark

### DIFF
--- a/src/main/kotlin/no/nav/medlemskap/inst/lytter/journalpost/JoarkClient.kt
+++ b/src/main/kotlin/no/nav/medlemskap/inst/lytter/journalpost/JoarkClient.kt
@@ -29,7 +29,6 @@ class JoarkClient(
                  header(HttpHeaders.ContentType, ContentType.Application.Json)
                  header(HttpHeaders.Authorization, "Bearer ${token.token}")
                  header("Nav-Call-Id", callId)
-                 header("Nav-User-Id","LovMeSrvUser")
                  header("X-Correlation-Id", callId)
                  body = JaksonParser().ToJson(journalpostRequest)
              }


### PR DESCRIPTION
`Nav-User-Id` er tenkt brukt i NAV identer og ikke hardkodede. Team Dokumentløsninger får flere varsler om dagen på grunn av feil bruk av denne headeren.